### PR TITLE
Debug profile booking cancellation functionality

### DIFF
--- a/surrey-foodbank/frontend/src/components/BookingInfo.jsx
+++ b/surrey-foodbank/frontend/src/components/BookingInfo.jsx
@@ -7,7 +7,7 @@ export default function BookingInfo({
   onChangeBooking,
   onBookAppointment,
 }) {
-  const hasAppointment = !!appointment?.dateLabel;
+  const hasAppointment = !!appointment?.day && !!appointment?.startTime;
 
   return (
     <Box>

--- a/surrey-foodbank/frontend/src/components/CancelBookingDialogue.jsx
+++ b/surrey-foodbank/frontend/src/components/CancelBookingDialogue.jsx
@@ -29,8 +29,10 @@ function CancelBookingDialogue({
         if (storedData) {
           const data = JSON.parse(storedData);
           // Clear only the booking info, keep personal info
-          data.dateLabel = "";
-          data.timeLabel = "";
+          data.day= "";
+          data.startTime= "";
+          data.dateLabel= "";
+          data.timeLabel= "";
           localStorage.setItem(`applicant_${applicantEmail}`, JSON.stringify(data));
         }
       }
@@ -47,9 +49,12 @@ function CancelBookingDialogue({
         if (storedData) {
           const data = JSON.parse(storedData);
           // Clear booking info
-          data.dateLabel = "";
-          data.timeLabel = "";
+          data.day= "";
+          data.startTime= "";
+          data.dateLabel= "";
+          data.timeLabel= "";
           localStorage.setItem(`applicant_${activeUser.email}`, JSON.stringify(data));
+          if (onCancelComplete) onCancelComplete(data);
         }
       }
       onClose();

--- a/surrey-foodbank/frontend/src/pages/applicant/Profile.jsx
+++ b/surrey-foodbank/frontend/src/pages/applicant/Profile.jsx
@@ -55,14 +55,7 @@ function Profile() {
 
     const storageKey = `applicant_${activeUser.email}`;
 
-    // Prioritize location.state (just completed booking) over stored data
-    if (location.state) {
-      setAppointment((prev) => ({ ...prev, ...location.state }));
-      localStorage.setItem(storageKey, JSON.stringify(location.state));
-      return;
-    }
-
-    // Otherwise load from localStorage
+    // Load from localStorage
     const storedData = JSON.parse(localStorage.getItem(storageKey) || "null");
     if (storedData) {
       setAppointment((prev) => ({ ...prev, ...storedData }));
@@ -125,6 +118,7 @@ function Profile() {
         timeLabel: "",
       });
     }
+    
   };
 
   return (
@@ -186,7 +180,7 @@ function Profile() {
               open={showCancelDialog}
               onClose={() => setShowCancelDialog(false)}
               appointment={appointment}
-              isStaff={true}
+              isStaff={false}
               applicantEmail={appointment?.applicantEmail || null}
               onCancelComplete={handleCancelComplete}
             />


### PR DESCRIPTION
 ## Description
 
- Cancelling an appointment on the applicant profile now updates appointment data in localStorage
- Refreshing on applicant profile maintains correct booking state

## Screenshots
Before cancelling appointment on applicant profile page
<img width="700" alt="image" src="https://github.com/user-attachments/assets/2d747a6c-951c-4a41-8878-300210fba2a0" />
After cancelling appointment on applicant profile page
<img width="700" alt="image" src="https://github.com/user-attachments/assets/13a1d00a-cdaf-44ab-89fb-be7949aa02ac" />



## Testing
Ran through the user flows, monitored localStorage, and refreshed pages to test persistence.

## Learning Sources
None